### PR TITLE
Enable Sentry debugging and auth tokens

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Example environment variables for Sentry
+VITE_SENTRY_DSN="https://examplePublicKey@o0.ingest.sentry.io/0"
+# Token used by the Vite plugin to upload source maps
+SENTRY_AUTH_TOKEN="your-auth-token"
+# Optional token for submitting user feedback from the browser
+VITE_SENTRY_AUTH_TOKEN="your-feedback-auth-token"

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ pnpm-debug.log*
 
 # Env files
 .env*
+!*.example
 
 # Tailwind CSS JIT cache
 .tailwindcss*

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Breakout Game
+
+This example React project integrates Sentry for error monitoring, session replays and user feedback.
+
+## Configuration
+
+1. Copy `.env.example` to `.env` and fill in the values for your Sentry project.
+2. Provide `SENTRY_AUTH_TOKEN` when building for production so source maps can be uploaded.
+3. Optionally set `VITE_SENTRY_AUTH_TOKEN` if you want to submit user feedback directly from the browser (not recommended for public deployments).
+
+## Development
+
+Run `npm run dev` to start the development server.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,8 +25,12 @@ function App() {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        // You need to add an auth token here for production use
-        // 'Authorization': 'Bearer <YOUR_AUTH_TOKEN>'
+        // The auth token is required to post user feedback via the Sentry API
+        // in production. It can be provided at build time using the
+        // VITE_SENTRY_AUTH_TOKEN environment variable.
+        ...(import.meta.env.VITE_SENTRY_AUTH_TOKEN && {
+          Authorization: `Bearer ${import.meta.env.VITE_SENTRY_AUTH_TOKEN}`,
+        }),
       },
       body: JSON.stringify({
         name: email || 'Anonymous',

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -2,7 +2,12 @@ import * as Sentry from '@sentry/react';
 
 // Initialize Sentry as early as possible
 Sentry.init({
-  dsn: import.meta.env.VITE_SENTRY_DSN || 'https://fff74e528b4cafe486546e7e9898d710@o4506312335294464.ingest.us.sentry.io/4509563503640576',
+  // DSN should be provided via environment variable `VITE_SENTRY_DSN`
+  // so errors are sent to the correct project. The fallback value is for local
+  // development only.
+  dsn:
+    import.meta.env.VITE_SENTRY_DSN ||
+    'https://fff74e528b4cafe486546e7e9898d710@o4506312335294464.ingest.us.sentry.io/4509563503640576',
   integrations: [
     Sentry.browserTracingIntegration(),
     Sentry.replayIntegration(),
@@ -13,4 +18,7 @@ Sentry.init({
   replaysSessionSampleRate: 1.0,
   replaysOnErrorSampleRate: 1.0,
   _experiments: { enableLogs: true },
+  // Print useful debugging information to the console so we can verify that
+  // events, replays and logs are actually being sent.
+  debug: true,
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,8 @@ import { sentryVitePlugin, type SentryVitePluginOptions } from '@sentry/vite-plu
 export default defineConfig({
   plugins: [
     react(),
+    // Upload source maps to Sentry during production builds. The auth token
+    // should be provided via the `SENTRY_AUTH_TOKEN` environment variable.
     sentryVitePlugin({
       org: 'rc-sentry-projects',
       project: 'breakout-game',


### PR DESCRIPTION
## Summary
- add sample env vars and README
- update Sentry initialization to show debug info
- allow sending auth token for user feedback
- document Sentry auth token usage in Vite config

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_685e29746d50832ba76c5455fa0b64df