### PR TITLE
fix(posthog): Add Vercel rewrites so production routes /ingest to PostHog

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,16 @@
+{
+  "rewrites": [
+    {
+      "source": "/ingest/static/:path*",
+      "destination": "https://us-assets.i.posthog.com/static/:path*"
+    },
+    {
+      "source": "/ingest/:path*",
+      "destination": "https://us.i.posthog.com/:path*"
+    },
+    {
+      "source": "/ingest",
+      "destination": "https://us.i.posthog.com"
+    }
+  ]
+}


### PR DESCRIPTION
## Why

The Vite dev proxy added in the previous PR only runs during `npm run dev`. On the deployed Vercel site (`broken-breakout-game.vercel.app`), `/ingest/*` requests have no rewrite, so PostHog receives nothing — that's why events still aren't showing up after the last merge.

## What

Add `vercel.json` with rewrites that mirror the Vite dev proxy:

- `/ingest/static/*` → `us-assets.i.posthog.com/static/*` (recorder.js asset host)
- `/ingest/*` → `us.i.posthog.com/*` (ingestion)

After this deploys, the deployed site will route capture events same-origin and ad blockers will leave them alone.

## Test plan

- [ ] Merge to `main`, wait for Vercel to redeploy
- [ ] Open `broken-breakout-game.vercel.app`, play a few seconds
- [ ] DevTools Network tab: confirm `POST /ingest/e/?…` returns 200
- [ ] PostHog dashboard: confirm `game_started` (and others) appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated analytics infrastructure configuration to properly route data collection endpoints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rahulchhabria/breakout-game/pull/11?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->