### PR TITLE
feat(game): Overhaul gameplay with combos, levels, and real power-ups

### DIFF
--- a/src/components/PongGame.tsx
+++ b/src/components/PongGame.tsx
@@ -16,6 +16,7 @@ interface Brick {
   destroyed: boolean;
   powerType?: 'bonus' | 'trap' | null;
   powerEffect?: string | null;
+  icon?: string | null;
 }
 
 interface PowerUp {
@@ -33,6 +34,27 @@ interface Ball {
   dy: number;
   speed: number;
   active: boolean;
+  launched: boolean;
+  trail: { x: number; y: number }[];
+}
+
+interface Particle {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  life: number;
+  maxLife: number;
+  color: string;
+  size: number;
+}
+
+interface FloatingText {
+  x: number;
+  y: number;
+  text: string;
+  life: number;
+  color: string;
 }
 
 interface GameState {
@@ -45,16 +67,25 @@ interface GameState {
   };
   bricks: Brick[];
   powerUps: PowerUp[];
+  particles: Particle[];
+  floatingTexts: FloatingText[];
   score: number;
   lives: number;
   level: number;
+  combo: number;
+  bestCombo: number;
   isPlaying: boolean;
   isPaused: boolean;
   gameOver: boolean;
   gameWon: boolean;
   paddleExpanded: boolean;
   expandTimer: number;
+  shrinkTimer: number;
   slowBallTimer: number;
+  reverseTimer: number;
+  shakeFrames: number;
+  shakeIntensity: number;
+  levelBannerFrames: number;
 }
 
 const CANVAS_WIDTH = 800;
@@ -63,23 +94,28 @@ const PADDLE_WIDTH = 120;
 const PADDLE_HEIGHT = 20;
 const BALL_SIZE = 12;
 const INITIAL_BALL_SPEED = 5;
-const MAX_BALL_SPEED = 9;
+const MAX_BALL_SPEED = 11;
 const SPEED_PER_BRICK = 0.04;
+const SPEED_PER_LEVEL = 0.6;
 const BRICK_WIDTH = 75;
 const BRICK_HEIGHT = 25;
 const BRICK_PADDING = 5;
 const BRICK_ROWS = 8;
 const BRICK_COLS = 10;
+const PADDLE_SPEED = 9;
+const MIN_DY_RATIO = 0.25; // ball will never travel flatter than this fraction of its speed
+const COMBO_RESET_ON_PADDLE = true;
+const LIFE_BONUS = 500;
 
 const BRICK_COLORS = [
-  { color: '#ef4444', points: 70, hits: 1 }, // Red - top row
-  { color: '#f97316', points: 60, hits: 1 }, // Orange
-  { color: '#eab308', points: 50, hits: 1 }, // Yellow
-  { color: '#22c55e', points: 40, hits: 1 }, // Green
-  { color: '#3b82f6', points: 30, hits: 1 }, // Blue
-  { color: '#8b5cf6', points: 20, hits: 1 }, // Purple
-  { color: '#ec4899', points: 15, hits: 1 }, // Pink - reduced from 2 hits to 1
-  { color: '#6b7280', points: 10, hits: 1 }, // Gray - reduced from 3 hits to 1
+  { color: '#ef4444', points: 70, hits: 1 },
+  { color: '#f97316', points: 60, hits: 1 },
+  { color: '#eab308', points: 50, hits: 1 },
+  { color: '#22c55e', points: 40, hits: 1 },
+  { color: '#3b82f6', points: 30, hits: 1 },
+  { color: '#8b5cf6', points: 20, hits: 1 },
+  { color: '#ec4899', points: 15, hits: 1 },
+  { color: '#6b7280', points: 10, hits: 1 },
 ];
 
 const BONUS_EFFECTS = [
@@ -93,36 +129,52 @@ const TRAP_EFFECTS = [
   { effect: 'reverse-controls', icon: '🔄', label: 'Reverse Controls' },
   { effect: 'lose-life', icon: '💔', label: 'Lose a Life' },
   { effect: 'speed-up', icon: '⚡', label: 'Speed Up Ball' },
-  { effect: 'slow-span', icon: '🐢', label: 'Slow Sentry Span' }, // NEW
+  { effect: 'slow-span', icon: '🐢', label: 'Slow Sentry Span' },
 ];
+
+const clampMinDy = (ball: Ball) => {
+  const minDy = ball.speed * MIN_DY_RATIO;
+  if (Math.abs(ball.dy) < minDy) {
+    const sign = ball.dy === 0 ? -1 : Math.sign(ball.dy);
+    const newDy = minDy * sign;
+    const remaining = Math.sqrt(Math.max(0, ball.speed * ball.speed - newDy * newDy));
+    ball.dx = remaining * (ball.dx === 0 ? (Math.random() > 0.5 ? 1 : -1) : Math.sign(ball.dx));
+    ball.dy = newDy;
+  }
+};
 
 export default function PongGame() {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const animationRef = useRef<number>();
+  const keysDownRef = useRef<{ left: boolean; right: boolean }>({ left: false, right: false });
+  const mousePaddleXRef = useRef<number | null>(null);
   const [soundEnabled, setSoundEnabled] = useState(true);
   const [initials, setInitials] = useState('');
   const [showInitialsPrompt, setShowInitialsPrompt] = useState(false);
   const [leaderboard, setLeaderboard] = useState<{ initials: string; score: number }[]>([]);
-  
-  const createBricks = (): Brick[] => {
+
+  const createBricks = (level = 1): Brick[] => {
     const bricks: Brick[] = [];
     const startX = (CANVAS_WIDTH - (BRICK_COLS * (BRICK_WIDTH + BRICK_PADDING) - BRICK_PADDING)) / 2;
     const startY = 60;
 
+    // Slightly more traps as you climb, but cap so it never feels unfair.
+    const bonusChance = 0.1;
+    const trapChance = Math.min(0.18, 0.08 + level * 0.015);
+
     for (let row = 0; row < BRICK_ROWS; row++) {
       for (let col = 0; col < BRICK_COLS; col++) {
         const brickType = BRICK_COLORS[row] || BRICK_COLORS[BRICK_COLORS.length - 1];
-        // Randomly assign powerType and effect
         let powerType: 'bonus' | 'trap' | null = null;
         let powerEffect: string | null = null;
         let icon: string | null = null;
         const rand = Math.random();
-        if (rand < 0.1) { // 10% chance bonus
+        if (rand < bonusChance) {
           powerType = 'bonus';
           const bonus = BONUS_EFFECTS[Math.floor(Math.random() * BONUS_EFFECTS.length)];
           powerEffect = bonus.effect;
           icon = bonus.icon;
-        } else if (rand < 0.2) { // 10% chance trap
+        } else if (rand < bonusChance + trapChance) {
           powerType = 'trap';
           const trap = TRAP_EFFECTS[Math.floor(Math.random() * TRAP_EFFECTS.length)];
           powerEffect = trap.effect;
@@ -141,21 +193,25 @@ export default function PongGame() {
           powerType,
           powerEffect,
           icon,
-        } as Brick & { icon?: string });
+        });
       }
     }
     return bricks;
   };
 
+  const buildInitialBall = (speed = INITIAL_BALL_SPEED): Ball => ({
+    x: CANVAS_WIDTH / 2,
+    y: CANVAS_HEIGHT - 60,
+    dx: 0,
+    dy: 0,
+    speed,
+    active: true,
+    launched: false,
+    trail: [],
+  });
+
   const [gameState, setGameState] = useState<GameState>({
-    balls: [{
-      x: CANVAS_WIDTH / 2,
-      y: CANVAS_HEIGHT / 2,
-      dx: INITIAL_BALL_SPEED * (Math.random() > 0.5 ? 1 : -1),
-      dy: -INITIAL_BALL_SPEED,
-      speed: INITIAL_BALL_SPEED,
-      active: true,
-    }],
+    balls: [buildInitialBall()],
     paddle: {
       x: CANVAS_WIDTH / 2 - PADDLE_WIDTH / 2,
       y: CANVAS_HEIGHT - 40,
@@ -164,47 +220,51 @@ export default function PongGame() {
     },
     bricks: createBricks(),
     powerUps: [],
+    particles: [],
+    floatingTexts: [],
     score: 0,
     lives: 3,
     level: 1,
+    combo: 0,
+    bestCombo: 0,
     isPlaying: false,
     isPaused: false,
     gameOver: false,
     gameWon: false,
     paddleExpanded: false,
     expandTimer: 0,
+    shrinkTimer: 0,
     slowBallTimer: 0,
+    reverseTimer: 0,
+    shakeFrames: 0,
+    shakeIntensity: 0,
+    levelBannerFrames: 0,
   });
 
-  const playSound = (frequency: number, duration: number = 100) => {
+  const playSound = useCallback((frequency: number, duration: number = 100) => {
     if (!soundEnabled) return;
-    
     try {
-      const audioContext = new (window.AudioContext || (window as typeof window & { webkitAudioContext: typeof AudioContext }).webkitAudioContext)();
+      const Ctx = window.AudioContext || (window as typeof window & { webkitAudioContext: typeof AudioContext }).webkitAudioContext;
+      const audioContext = new Ctx();
       const oscillator = audioContext.createOscillator();
       const gainNode = audioContext.createGain();
-      
       oscillator.connect(gainNode);
       gainNode.connect(audioContext.destination);
-      
       oscillator.frequency.value = frequency;
       oscillator.type = 'square';
-      
       gainNode.gain.setValueAtTime(0.1, audioContext.currentTime);
       gainNode.gain.exponentialRampToValueAtTime(0.01, audioContext.currentTime + duration / 1000);
-      
       oscillator.start(audioContext.currentTime);
       oscillator.stop(audioContext.currentTime + duration / 1000);
     } catch {
       // Silently fail if audio context is not available
     }
-  };
+  }, [soundEnabled]);
 
   const createPowerUp = (x: number, y: number): PowerUp => {
     const types: PowerUp['type'][] = ['expand', 'multiball', 'slowball', 'extralife'];
     const colors = ['#fbbf24', '#10b981', '#3b82f6', '#ef4444'];
     const type = types[Math.floor(Math.random() * types.length)];
-    
     return {
       x,
       y,
@@ -214,21 +274,60 @@ export default function PongGame() {
     };
   };
 
-  const handleMouseMove = useCallback((e: MouseEvent) => {
-    const canvas = canvasRef.current;
-    if (!canvas) return;
-    
-    const rect = canvas.getBoundingClientRect();
-    const scaleX = canvas.width / rect.width;
-    const mouseX = (e.clientX - rect.left) * scaleX;
-    const paddleWidth = gameState.paddleExpanded ? PADDLE_WIDTH * 1.5 : PADDLE_WIDTH;
-    const paddleX = Math.max(0, Math.min(CANVAS_WIDTH - paddleWidth, mouseX - paddleWidth / 2));
-    
-    setGameState(prev => ({
-      ...prev,
-      paddle: { ...prev.paddle, x: paddleX, width: paddleWidth },
-    }));
-  }, [gameState.paddleExpanded]);
+  const spawnParticles = (state: GameState, x: number, y: number, color: string, count = 10) => {
+    for (let i = 0; i < count; i++) {
+      const angle = Math.random() * Math.PI * 2;
+      const speed = 1 + Math.random() * 3;
+      const life = 20 + Math.floor(Math.random() * 15);
+      state.particles.push({
+        x,
+        y,
+        vx: Math.cos(angle) * speed,
+        vy: Math.sin(angle) * speed - 1, // slight upward bias
+        life,
+        maxLife: life,
+        color,
+        size: 2 + Math.random() * 2,
+      });
+    }
+    // Hard cap so a long combo doesn't tank perf.
+    if (state.particles.length > 250) {
+      state.particles.splice(0, state.particles.length - 250);
+    }
+  };
+
+  const spawnFloatingText = (state: GameState, x: number, y: number, text: string, color: string) => {
+    state.floatingTexts.push({ x, y, text, life: 45, color });
+    if (state.floatingTexts.length > 30) state.floatingTexts.shift();
+  };
+
+  const triggerShake = (state: GameState, intensity: number, frames: number) => {
+    if (intensity > state.shakeIntensity) {
+      state.shakeIntensity = intensity;
+      state.shakeFrames = frames;
+    }
+  };
+
+  const launchAllStuckBalls = () => {
+    setGameState(prev => {
+      if (!prev.isPlaying || prev.isPaused) return prev;
+      let changed = false;
+      const balls = prev.balls.map(ball => {
+        if (ball.active && !ball.launched) {
+          changed = true;
+          const angle = (Math.random() - 0.5) * Math.PI / 4; // -22.5°..+22.5°
+          return {
+            ...ball,
+            launched: true,
+            dx: ball.speed * Math.sin(angle),
+            dy: -ball.speed * Math.cos(angle),
+          };
+        }
+        return ball;
+      });
+      return changed ? { ...prev, balls } : prev;
+    });
+  };
 
   const startGame = () => {
     log.info('Game started', { lives: gameState.lives, level: gameState.level });
@@ -247,49 +346,134 @@ export default function PongGame() {
     log.debug('Game pause state changed', {
       isPaused: newPauseState,
       score: gameState.score,
-      lives: gameState.lives
+      lives: gameState.lives,
     });
     posthog.capture(newPauseState ? 'game_paused' : 'game_resumed', {
       score: gameState.score,
       lives: gameState.lives,
     });
-    setGameState(prev => ({
-      ...prev,
-      isPaused: newPauseState,
-    }));
+    setGameState(prev => ({ ...prev, isPaused: newPauseState }));
   };
 
   const resetGame = () => {
     log.info('Game reset', { finalScore: gameState.score });
     posthog.capture('game_reset', { score: gameState.score, lives: gameState.lives });
     setGameState({
-      balls: [{
-        x: CANVAS_WIDTH / 2,
-        y: CANVAS_HEIGHT / 2,
-        dx: INITIAL_BALL_SPEED * (Math.random() > 0.5 ? 1 : -1),
-        dy: -INITIAL_BALL_SPEED,
-        speed: INITIAL_BALL_SPEED,
-        active: true,
-      }],
+      balls: [buildInitialBall()],
       paddle: {
         x: CANVAS_WIDTH / 2 - PADDLE_WIDTH / 2,
         y: CANVAS_HEIGHT - 40,
         width: PADDLE_WIDTH,
         height: PADDLE_HEIGHT,
       },
-      bricks: createBricks(),
+      bricks: createBricks(1),
       powerUps: [],
+      particles: [],
+      floatingTexts: [],
       score: 0,
       lives: 3,
       level: 1,
+      combo: 0,
+      bestCombo: 0,
       isPlaying: false,
       isPaused: false,
       gameOver: false,
       gameWon: false,
       paddleExpanded: false,
       expandTimer: 0,
+      shrinkTimer: 0,
       slowBallTimer: 0,
+      reverseTimer: 0,
+      shakeFrames: 0,
+      shakeIntensity: 0,
+      levelBannerFrames: 0,
     });
+  };
+
+  const applyBonusEffect = (state: GameState, effect: string | null | undefined, brickX: number, brickY: number) => {
+    switch (effect) {
+      case 'extra-life':
+        state.lives += 1;
+        spawnFloatingText(state, brickX, brickY, '+1 LIFE', '#34d399');
+        break;
+      case 'expand-paddle':
+        state.paddleExpanded = true;
+        state.expandTimer = 600;
+        state.shrinkTimer = 0;
+        state.paddle.width = PADDLE_WIDTH * 1.5;
+        spawnFloatingText(state, brickX, brickY, 'EXPAND', '#34d399');
+        break;
+      case 'multiball': {
+        if (state.balls.length < 6) {
+          const seed = state.balls.find(b => b.launched) || state.balls[0];
+          const spawnAngles = [Math.PI / 8, -Math.PI / 8];
+          spawnAngles.forEach(angle => {
+            state.balls.push({
+              x: seed.x,
+              y: seed.y,
+              dx: seed.speed * Math.sin(angle),
+              dy: -seed.speed * Math.cos(angle),
+              speed: seed.speed,
+              active: true,
+              launched: true,
+              trail: [],
+            });
+          });
+        }
+        spawnFloatingText(state, brickX, brickY, 'MULTI-BALL', '#34d399');
+        break;
+      }
+      case 'score-boost':
+        state.score += 500;
+        spawnFloatingText(state, brickX, brickY, '+500', '#fbbf24');
+        break;
+    }
+  };
+
+  const applyTrapEffect = (state: GameState, effect: string | null | undefined, brickX: number, brickY: number) => {
+    switch (effect) {
+      case 'shrink-paddle':
+        state.paddleExpanded = false;
+        state.expandTimer = 0;
+        state.shrinkTimer = 480;
+        state.paddle.width = PADDLE_WIDTH * 0.7;
+        spawnFloatingText(state, brickX, brickY, 'SHRINK', '#f87171');
+        break;
+      case 'reverse-controls':
+        state.reverseTimer = 360;
+        spawnFloatingText(state, brickX, brickY, 'REVERSED', '#f87171');
+        break;
+      case 'lose-life':
+        if (state.lives > 1) {
+          state.lives -= 1;
+          spawnFloatingText(state, brickX, brickY, '-1 LIFE', '#f87171');
+          triggerShake(state, 10, 12);
+        } else {
+          // Don't end the game from a brick trap — convert to a different penalty.
+          state.score = Math.max(0, state.score - 200);
+          spawnFloatingText(state, brickX, brickY, '-200', '#f87171');
+        }
+        break;
+      case 'speed-up':
+        state.balls.forEach(ball => {
+          if (!ball.launched) return;
+          const newSpeed = Math.min(MAX_BALL_SPEED, ball.speed * 1.25);
+          const scale = newSpeed / Math.max(0.01, ball.speed);
+          ball.dx *= scale;
+          ball.dy *= scale;
+          ball.speed = newSpeed;
+        });
+        spawnFloatingText(state, brickX, brickY, 'SPEED UP', '#f87171');
+        break;
+      case 'slow-span':
+        // Intentional slow span for the Sentry demo.
+        Sentry.startSpan({ name: 'intentional-slow-span' }, () => {
+          const start = Date.now();
+          while (Date.now() - start < 400) { /* intentional busy-wait */ }
+        });
+        spawnFloatingText(state, brickX, brickY, 'SLOW SPAN', '#f87171');
+        break;
+    }
   };
 
   const updateGame = useCallback(() => {
@@ -297,8 +481,30 @@ export default function PongGame() {
       if (!prev.isPlaying || prev.isPaused || prev.gameOver || prev.gameWon) return prev;
 
       const newState = { ...prev };
-      
-      // Update power-up timers
+      newState.paddle = { ...prev.paddle };
+      newState.balls = prev.balls.map(b => ({ ...b, trail: b.trail.slice() }));
+      newState.bricks = prev.bricks.map(br => ({ ...br }));
+      newState.powerUps = prev.powerUps.map(p => ({ ...p }));
+      newState.particles = prev.particles.map(p => ({ ...p }));
+      newState.floatingTexts = prev.floatingTexts.map(t => ({ ...t }));
+
+      // Keyboard paddle movement (in-loop so it works during pauses-of-input)
+      const reversed = newState.reverseTimer > 0;
+      let dir = 0;
+      if (keysDownRef.current.left) dir -= 1;
+      if (keysDownRef.current.right) dir += 1;
+      if (reversed) dir *= -1;
+      if (dir !== 0) {
+        newState.paddle.x = Math.max(0, Math.min(CANVAS_WIDTH - newState.paddle.width, newState.paddle.x + dir * PADDLE_SPEED));
+        mousePaddleXRef.current = null; // keyboard takes over from mouse
+      } else if (mousePaddleXRef.current !== null) {
+        const target = reversed
+          ? CANVAS_WIDTH - mousePaddleXRef.current - newState.paddle.width
+          : mousePaddleXRef.current;
+        newState.paddle.x = Math.max(0, Math.min(CANVAS_WIDTH - newState.paddle.width, target));
+      }
+
+      // Power-up timers
       if (newState.expandTimer > 0) {
         newState.expandTimer -= 1;
         if (newState.expandTimer <= 0) {
@@ -306,89 +512,126 @@ export default function PongGame() {
           newState.paddle.width = PADDLE_WIDTH;
         }
       }
-      
-      if (newState.slowBallTimer > 0) {
-        newState.slowBallTimer -= 1;
-      }
-
-      // Update balls
-      newState.balls = newState.balls.filter(ball => {
-        if (!ball.active) {
-          log.debug('Ball lost', { 
-            position: { x: ball.x, y: ball.y },
-            velocity: { dx: ball.dx, dy: ball.dy }
-          });
-          return false;
+      if (newState.shrinkTimer > 0) {
+        newState.shrinkTimer -= 1;
+        if (newState.shrinkTimer <= 0) {
+          newState.paddle.width = PADDLE_WIDTH;
         }
-        return true;
-      });
-      
+      }
+      if (newState.slowBallTimer > 0) newState.slowBallTimer -= 1;
+      if (newState.reverseTimer > 0) newState.reverseTimer -= 1;
+      if (newState.shakeFrames > 0) {
+        newState.shakeFrames -= 1;
+        if (newState.shakeFrames <= 0) newState.shakeIntensity = 0;
+      }
+      if (newState.levelBannerFrames > 0) newState.levelBannerFrames -= 1;
+
+      // Ball physics
+      const speedMultiplier = newState.slowBallTimer > 0 ? 0.6 : 1;
       newState.balls.forEach(ball => {
-        const speedMultiplier = newState.slowBallTimer > 0 ? 0.6 : 1;
+        if (!ball.active) return;
+
+        // If not launched yet, glue to paddle center.
+        if (!ball.launched) {
+          ball.x = newState.paddle.x + newState.paddle.width / 2;
+          ball.y = newState.paddle.y - BALL_SIZE / 2 - 2;
+          ball.trail.length = 0;
+          return;
+        }
+
+        // Trail update
+        ball.trail.push({ x: ball.x, y: ball.y });
+        if (ball.trail.length > 10) ball.trail.shift();
+
         ball.x += ball.dx * speedMultiplier;
         ball.y += ball.dy * speedMultiplier;
 
-        // Ball collision with walls
-        if (ball.x <= BALL_SIZE / 2 || ball.x >= CANVAS_WIDTH - BALL_SIZE / 2) {
-          ball.dx = -ball.dx;
-          playSound(220, 100);
+        // Wall bounces
+        if (ball.x <= BALL_SIZE / 2) {
+          ball.x = BALL_SIZE / 2;
+          ball.dx = Math.abs(ball.dx);
+          playSound(220, 60);
+        } else if (ball.x >= CANVAS_WIDTH - BALL_SIZE / 2) {
+          ball.x = CANVAS_WIDTH - BALL_SIZE / 2;
+          ball.dx = -Math.abs(ball.dx);
+          playSound(220, 60);
         }
-        
         if (ball.y <= BALL_SIZE / 2) {
-          ball.dy = -ball.dy;
-          playSound(220, 100);
+          ball.y = BALL_SIZE / 2;
+          ball.dy = Math.abs(ball.dy);
+          playSound(220, 60);
         }
 
-        // Ball collision with paddle
+        // Paddle collision
         if (
+          ball.dy > 0 &&
           ball.y + BALL_SIZE / 2 >= newState.paddle.y &&
           ball.y - BALL_SIZE / 2 <= newState.paddle.y + newState.paddle.height &&
           ball.x >= newState.paddle.x &&
-          ball.x <= newState.paddle.x + newState.paddle.width &&
-          ball.dy > 0
+          ball.x <= newState.paddle.x + newState.paddle.width
         ) {
           const hitPos = (ball.x - newState.paddle.x) / newState.paddle.width;
-          const angle = (hitPos - 0.5) * Math.PI / 3;
-          
-          ball.dy = -Math.abs(ball.dy);
+          const angle = (hitPos - 0.5) * (Math.PI * 0.7); // up to ~63° off-vertical
           ball.dx = ball.speed * Math.sin(angle);
           ball.dy = -ball.speed * Math.cos(angle);
-          
-          playSound(330, 100);
+          ball.y = newState.paddle.y - BALL_SIZE / 2 - 1;
+          clampMinDy(ball);
+          playSound(330, 80);
+          if (COMBO_RESET_ON_PADDLE && newState.combo > 0) {
+            newState.combo = 0;
+          }
         }
 
-        // Ball collision with bricks
-        newState.bricks.forEach(brick => {
-          if (brick.destroyed) return;
-          
+        // Brick collision (only handle first hit per frame to avoid double-bounce stuck states)
+        for (const brick of newState.bricks) {
+          if (brick.destroyed) continue;
           if (
             ball.x + BALL_SIZE / 2 >= brick.x &&
             ball.x - BALL_SIZE / 2 <= brick.x + brick.width &&
             ball.y + BALL_SIZE / 2 >= brick.y &&
             ball.y - BALL_SIZE / 2 <= brick.y + brick.height
           ) {
-            // Determine collision side
             const ballCenterX = ball.x;
             const ballCenterY = ball.y;
             const brickCenterX = brick.x + brick.width / 2;
             const brickCenterY = brick.y + brick.height / 2;
-            
             const deltaX = ballCenterX - brickCenterX;
             const deltaY = ballCenterY - brickCenterY;
-            
+
             if (Math.abs(deltaX / brick.width) > Math.abs(deltaY / brick.height)) {
-              ball.dx = -ball.dx;
+              ball.dx = deltaX > 0 ? Math.abs(ball.dx) : -Math.abs(ball.dx);
             } else {
-              ball.dy = -ball.dy;
+              ball.dy = deltaY > 0 ? Math.abs(ball.dy) : -Math.abs(ball.dy);
             }
-            
+            clampMinDy(ball);
+
             brick.hits += 1;
-            newState.score += brick.points;
 
             if (brick.hits >= brick.maxHits) {
               brick.destroyed = true;
-              playSound(440, 150);
 
+              // Combo + multiplier
+              newState.combo += 1;
+              if (newState.combo > newState.bestCombo) newState.bestCombo = newState.combo;
+              const multiplier = 1 + Math.floor((newState.combo - 1) / 4); // x1 at 1-4, x2 at 5-8, ...
+              const gained = brick.points * multiplier;
+              newState.score += gained;
+
+              if (multiplier > 1) {
+                spawnFloatingText(
+                  newState,
+                  brick.x + brick.width / 2,
+                  brick.y + brick.height / 2,
+                  `+${gained} x${multiplier}`,
+                  '#fbbf24'
+                );
+              }
+
+              spawnParticles(newState, brick.x + brick.width / 2, brick.y + brick.height / 2, brick.color, 8);
+              triggerShake(newState, 3, 4);
+              playSound(440 + Math.min(800, newState.combo * 12), 110);
+
+              // Speed up the ball slightly per brick (capped)
               const newSpeed = Math.min(MAX_BALL_SPEED, ball.speed + SPEED_PER_BRICK);
               if (newSpeed !== ball.speed) {
                 const scale = newSpeed / ball.speed;
@@ -396,7 +639,8 @@ export default function PongGame() {
                 ball.dy *= scale;
                 ball.speed = newSpeed;
               }
-              // Add recent logs as breadcrumbs before capturing exception
+
+              // Sentry demo: capture every brick break (intentional, this is a demo app)
               getRecentLogs().forEach(logEntry => {
                 Sentry.addBreadcrumb({
                   category: 'log',
@@ -406,48 +650,44 @@ export default function PongGame() {
                   timestamp: Math.floor(logEntry.timestamp / 1000),
                 });
               });
-              // Trigger a unique Sentry error for each brick broken
               Sentry.captureException(
                 new Error(`Brick broken at (${brick.x},${brick.y}) - color: ${brick.color} - points: ${brick.points}`),
-                {
-                  fingerprint: [
-                    'brick-broken',
-                    brick.color // Group by color only
-                  ]
-                }
+                { fingerprint: ['brick-broken', brick.color] }
               );
 
-              // Handle trap/bonus effects
-              if (brick.powerType === 'trap' && brick.powerEffect === 'slow-span') {
-                Sentry.startSpan({ name: 'intentional-slow-span' }, () => {
-                  const start = Date.now();
-                  while (Date.now() - start < 400) { /* intentional busy-wait */ }
-                });
+              // Apply bonus/trap effects
+              if (brick.powerType === 'bonus') {
+                applyBonusEffect(newState, brick.powerEffect, brick.x + brick.width / 2, brick.y + brick.height / 2);
+              } else if (brick.powerType === 'trap') {
+                applyTrapEffect(newState, brick.powerEffect, brick.x + brick.width / 2, brick.y + brick.height / 2);
               }
-              
-              // Chance to drop power-up
-              if (Math.random() < 0.15) {
+
+              // Drop a falling power-up sometimes (independent of bonus bricks)
+              if (Math.random() < 0.12) {
                 newState.powerUps.push(createPowerUp(brick.x + brick.width / 2, brick.y + brick.height));
               }
             } else {
-              playSound(330, 100);
+              playSound(330, 80);
             }
+            break; // resolve one brick per frame per ball
           }
-        });
+        }
 
-        // Ball goes off screen
+        // Off-screen
         if (ball.y > CANVAS_HEIGHT) {
           ball.active = false;
         }
       });
 
-      // Check if all balls are gone
+      // Compact balls
+      newState.balls = newState.balls.filter(b => b.active);
+
+      // Life loss
       if (newState.balls.length === 0) {
         newState.lives -= 1;
-        log.warn('Life lost', {
-          remainingLives: newState.lives,
-          score: newState.score
-        });
+        newState.combo = 0;
+        triggerShake(newState, 14, 18);
+        log.warn('Life lost', { remainingLives: newState.lives, score: newState.score });
         posthog.capture('life_lost', { remaining_lives: newState.lives, score: newState.score });
 
         if (newState.lives <= 0) {
@@ -455,129 +695,180 @@ export default function PongGame() {
           log.info('Game over', {
             finalScore: newState.score,
             bricksDestroyed,
-            totalBricks: newState.bricks.length
+            totalBricks: newState.bricks.length,
           });
           posthog.capture('game_over', {
             score: newState.score,
             bricks_destroyed: bricksDestroyed,
             total_bricks: newState.bricks.length,
+            best_combo: newState.bestCombo,
+            level: newState.level,
           });
           newState.gameOver = true;
           newState.isPlaying = false;
         } else {
-          // Add new ball
-          newState.balls.push({
-            x: CANVAS_WIDTH / 2,
-            y: CANVAS_HEIGHT / 2,
-            dx: INITIAL_BALL_SPEED * (Math.random() > 0.5 ? 1 : -1),
-            dy: -INITIAL_BALL_SPEED,
-            speed: INITIAL_BALL_SPEED,
-            active: true,
-          });
+          newState.balls.push(buildInitialBall(INITIAL_BALL_SPEED + (newState.level - 1) * SPEED_PER_LEVEL));
         }
       }
 
       // Update power-ups
       newState.powerUps = newState.powerUps.filter(powerUp => {
         if (!powerUp.active) return false;
-        
-        powerUp.y += 2;
-        
-        // Check collision with paddle
+        powerUp.y += 2.2;
+
         if (
           powerUp.y + 10 >= newState.paddle.y &&
           powerUp.y <= newState.paddle.y + newState.paddle.height &&
           powerUp.x + 10 >= newState.paddle.x &&
           powerUp.x - 10 <= newState.paddle.x + newState.paddle.width
         ) {
-          log.info('Power-up collected', {
-            type: powerUp.type,
-            position: { x: powerUp.x, y: powerUp.y }
-          });
+          log.info('Power-up collected', { type: powerUp.type });
           posthog.capture('power_up_collected', { type: powerUp.type, score: newState.score });
-
           playSound(550, 200);
-          
+
           switch (powerUp.type) {
             case 'expand':
               newState.paddleExpanded = true;
-              newState.expandTimer = 600; // 10 seconds at 60fps
+              newState.expandTimer = 600;
+              newState.shrinkTimer = 0;
               newState.paddle.width = PADDLE_WIDTH * 1.5;
+              spawnFloatingText(newState, powerUp.x, powerUp.y, 'EXPAND', '#34d399');
               break;
             case 'multiball':
-              if (newState.balls.length < 5) {
-                const mainBall = newState.balls[0];
-                const spawnAngles = [Math.PI / 6, -Math.PI / 6];
+              if (newState.balls.length < 6) {
+                const seed = newState.balls.find(b => b.launched) || newState.balls[0];
+                const spawnAngles = [Math.PI / 8, -Math.PI / 8];
                 spawnAngles.forEach(angle => {
                   newState.balls.push({
-                    x: mainBall.x,
-                    y: mainBall.y,
-                    dx: mainBall.speed * Math.sin(angle),
-                    dy: -mainBall.speed * Math.cos(angle),
-                    speed: mainBall.speed,
+                    x: seed.x,
+                    y: seed.y,
+                    dx: seed.speed * Math.sin(angle),
+                    dy: -seed.speed * Math.cos(angle),
+                    speed: seed.speed,
                     active: true,
+                    launched: true,
+                    trail: [],
                   });
                 });
               }
+              spawnFloatingText(newState, powerUp.x, powerUp.y, 'MULTI-BALL', '#34d399');
               break;
             case 'slowball':
-              newState.slowBallTimer = 600; // 10 seconds
+              newState.slowBallTimer = 600;
+              spawnFloatingText(newState, powerUp.x, powerUp.y, 'SLOW BALL', '#60a5fa');
               break;
             case 'extralife':
               newState.lives += 1;
+              spawnFloatingText(newState, powerUp.x, powerUp.y, '+1 LIFE', '#34d399');
               break;
           }
-          
           powerUp.active = false;
           return false;
         }
-        
-        // Remove if off screen
+
         if (powerUp.y > CANVAS_HEIGHT) {
           powerUp.active = false;
           return false;
         }
-        
         return true;
       });
 
-      // Check win condition
+      // Particles
+      newState.particles = newState.particles.filter(p => {
+        p.x += p.vx;
+        p.y += p.vy;
+        p.vy += 0.12; // gravity
+        p.life -= 1;
+        return p.life > 0;
+      });
+
+      // Floating texts
+      newState.floatingTexts = newState.floatingTexts.filter(t => {
+        t.y -= 0.6;
+        t.life -= 1;
+        return t.life > 0;
+      });
+
+      // Level cleared?
       const remainingBricks = newState.bricks.filter(brick => !brick.destroyed);
       if (remainingBricks.length === 0) {
-        log.info('Game won', {
-          finalScore: newState.score,
-          lives: newState.lives,
-          powerUpsCollected: newState.powerUps.length
-        });
-        posthog.capture('game_won', {
+        const lifeBonus = newState.lives * LIFE_BONUS;
+        newState.score += lifeBonus;
+        log.info('Level cleared', {
           score: newState.score,
-          lives_remaining: newState.lives,
-          total_bricks: newState.bricks.length,
+          lives: newState.lives,
+          level: newState.level,
+          lifeBonus,
         });
-        newState.gameWon = true;
-        newState.isPlaying = false;
-        playSound(660, 500);
+        posthog.capture('level_cleared', {
+          score: newState.score,
+          lives: newState.lives,
+          level: newState.level,
+          life_bonus: lifeBonus,
+          best_combo: newState.bestCombo,
+        });
+
+        if (newState.level >= 5) {
+          // Final clear → victory screen
+          posthog.capture('game_won', {
+            score: newState.score,
+            lives_remaining: newState.lives,
+            total_bricks: newState.bricks.length,
+            best_combo: newState.bestCombo,
+            level: newState.level,
+          });
+          newState.gameWon = true;
+          newState.isPlaying = false;
+          playSound(660, 500);
+        } else {
+          // Advance to next level
+          newState.level += 1;
+          newState.bricks = createBricks(newState.level);
+          newState.powerUps = [];
+          newState.combo = 0;
+          newState.levelBannerFrames = 120;
+          const baseSpeed = INITIAL_BALL_SPEED + (newState.level - 1) * SPEED_PER_LEVEL;
+          newState.balls = [{
+            ...buildInitialBall(baseSpeed),
+            x: newState.paddle.x + newState.paddle.width / 2,
+            y: newState.paddle.y - BALL_SIZE / 2 - 2,
+          }];
+          newState.paddleExpanded = false;
+          newState.expandTimer = 0;
+          newState.shrinkTimer = 0;
+          newState.slowBallTimer = 0;
+          newState.reverseTimer = 0;
+          newState.paddle.width = PADDLE_WIDTH;
+          spawnFloatingText(newState, CANVAS_WIDTH / 2, CANVAS_HEIGHT / 2, `+${lifeBonus} LIFE BONUS`, '#fbbf24');
+        }
       }
 
       return newState;
     });
+    // applyBonusEffect/applyTrapEffect are pure helpers that take state as an argument; no need to track them.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [playSound]);
 
   const render = useCallback(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
-
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
 
-    // Clear canvas with gradient background
+    // Background
     const gradient = ctx.createLinearGradient(0, 0, 0, CANVAS_HEIGHT);
     gradient.addColorStop(0, '#0f0f23');
     gradient.addColorStop(1, '#1a1a2e');
     ctx.fillStyle = gradient;
     ctx.fillRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
 
-    // Draw game border
+    // Apply screen shake to gameplay layer
+    const shakeX = gameState.shakeFrames > 0 ? (Math.random() - 0.5) * gameState.shakeIntensity : 0;
+    const shakeY = gameState.shakeFrames > 0 ? (Math.random() - 0.5) * gameState.shakeIntensity : 0;
+    ctx.save();
+    ctx.translate(shakeX, shakeY);
+
+    // Border
     ctx.strokeStyle = '#4f46e5';
     ctx.lineWidth = 2;
     ctx.setLineDash([10, 5]);
@@ -585,69 +876,79 @@ export default function PongGame() {
     ctx.setLineDash([]);
 
     if (gameState.isPlaying && !gameState.gameOver && !gameState.gameWon) {
-      // Draw bricks
+      // Bricks
       gameState.bricks.forEach(brick => {
         if (brick.destroyed) return;
-        
-        // Brick damage effect
-        const alpha = 1 - (brick.hits / brick.maxHits) * 0.5;
+        const alpha = 1 - (brick.hits / brick.maxHits) * 0.4;
         ctx.globalAlpha = alpha;
 
-        // Special color for bonus/trap bricks
         let brickColor = brick.color;
-        if (brick.powerType === 'bonus') {
-          brickColor = '#facc15'; // Gold/yellow for bonus
-        } else if (brick.powerType === 'trap') {
-          brickColor = '#ef4444'; // Red for trap
-        }
+        if (brick.powerType === 'bonus') brickColor = '#facc15';
+        else if (brick.powerType === 'trap') brickColor = '#ef4444';
 
-        // Brick gradient
-        const brickGradient = ctx.createLinearGradient(
-          brick.x, brick.y,
-          brick.x, brick.y + brick.height
-        );
+        const brickGradient = ctx.createLinearGradient(brick.x, brick.y, brick.x, brick.y + brick.height);
         brickGradient.addColorStop(0, brickColor);
         brickGradient.addColorStop(1, brickColor + '80');
 
         ctx.fillStyle = brickGradient;
         ctx.fillRect(brick.x, brick.y, brick.width, brick.height);
-
-        // Brick border
         ctx.strokeStyle = brickColor;
         ctx.lineWidth = 2;
         ctx.strokeRect(brick.x, brick.y, brick.width, brick.height);
 
-        // Draw icon for bonus/trap
-        if (brick.powerType && typeof (brick as { icon?: unknown }).icon === 'string') {
+        if (brick.icon) {
           ctx.globalAlpha = 1;
-          ctx.font = '20px Arial';
+          ctx.font = '18px Arial';
           ctx.textAlign = 'center';
           ctx.textBaseline = 'middle';
-          ctx.fillStyle = brick.powerType === 'bonus' ? '#fffde4' : '#ffb4b4';
-          ctx.fillText((brick as { icon?: string }).icon!, brick.x + brick.width / 2, brick.y + brick.height / 2);
+          ctx.fillStyle = brick.powerType === 'bonus' ? '#fffde4' : '#ffe4e4';
+          ctx.fillText(brick.icon, brick.x + brick.width / 2, brick.y + brick.height / 2);
         }
-
         ctx.globalAlpha = 1;
       });
 
-      // Draw balls
+      // Power-ups
+      gameState.powerUps.forEach(powerUp => {
+        if (!powerUp.active) return;
+        ctx.fillStyle = powerUp.color;
+        ctx.shadowColor = powerUp.color;
+        ctx.shadowBlur = 10;
+        ctx.beginPath();
+        ctx.arc(powerUp.x, powerUp.y, 9, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.shadowBlur = 0;
+        ctx.fillStyle = '#ffffff';
+        ctx.font = 'bold 12px Arial';
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        const symbol = powerUp.type === 'expand' ? '↔'
+          : powerUp.type === 'multiball' ? '●'
+          : powerUp.type === 'slowball' ? '⏱' : '♥';
+        ctx.fillText(symbol, powerUp.x, powerUp.y);
+      });
+
+      // Ball trails
       gameState.balls.forEach(ball => {
         if (!ball.active) return;
-        
-        const ballGradient = ctx.createRadialGradient(
-          ball.x, ball.y, 0,
-          ball.x, ball.y, BALL_SIZE
-        );
+        ball.trail.forEach((p, i) => {
+          const t = (i + 1) / ball.trail.length;
+          ctx.globalAlpha = t * 0.35;
+          ctx.fillStyle = '#60a5fa';
+          ctx.beginPath();
+          ctx.arc(p.x, p.y, (BALL_SIZE / 2) * (0.4 + t * 0.6), 0, Math.PI * 2);
+          ctx.fill();
+        });
+        ctx.globalAlpha = 1;
+      });
+
+      // Balls
+      gameState.balls.forEach(ball => {
+        if (!ball.active) return;
+        const ballGradient = ctx.createRadialGradient(ball.x, ball.y, 0, ball.x, ball.y, BALL_SIZE);
         ballGradient.addColorStop(0, '#ffffff');
         ballGradient.addColorStop(0.7, '#60a5fa');
         ballGradient.addColorStop(1, '#3b82f6');
-        
         ctx.fillStyle = ballGradient;
-        ctx.beginPath();
-        ctx.arc(ball.x, ball.y, BALL_SIZE / 2, 0, Math.PI * 2);
-        ctx.fill();
-
-        // Ball glow
         ctx.shadowColor = '#60a5fa';
         ctx.shadowBlur = 15;
         ctx.beginPath();
@@ -656,13 +957,16 @@ export default function PongGame() {
         ctx.shadowBlur = 0;
       });
 
-      // Draw paddle
+      // Paddle
       const paddleGradient = ctx.createLinearGradient(
         gameState.paddle.x, gameState.paddle.y,
         gameState.paddle.x, gameState.paddle.y + gameState.paddle.height
       );
-      
-      if (gameState.paddleExpanded) {
+      if (gameState.shrinkTimer > 0) {
+        paddleGradient.addColorStop(0, '#f87171');
+        paddleGradient.addColorStop(1, '#dc2626');
+        ctx.shadowColor = '#f87171';
+      } else if (gameState.paddleExpanded) {
         paddleGradient.addColorStop(0, '#10b981');
         paddleGradient.addColorStop(1, '#059669');
         ctx.shadowColor = '#10b981';
@@ -671,68 +975,152 @@ export default function PongGame() {
         paddleGradient.addColorStop(1, '#f59e0b');
         ctx.shadowColor = '#fbbf24';
       }
-      
       ctx.fillStyle = paddleGradient;
-      ctx.shadowBlur = 10;
-      ctx.fillRect(
-        gameState.paddle.x,
-        gameState.paddle.y,
-        gameState.paddle.width,
-        gameState.paddle.height
-      );
+      ctx.shadowBlur = 12;
+      ctx.fillRect(gameState.paddle.x, gameState.paddle.y, gameState.paddle.width, gameState.paddle.height);
       ctx.shadowBlur = 0;
 
-      // Draw power-ups
-      gameState.powerUps.forEach(powerUp => {
-        if (!powerUp.active) return;
-        
-        ctx.fillStyle = powerUp.color;
-        ctx.shadowColor = powerUp.color;
-        ctx.shadowBlur = 8;
-        ctx.beginPath();
-        ctx.arc(powerUp.x, powerUp.y, 8, 0, Math.PI * 2);
-        ctx.fill();
-        ctx.shadowBlur = 0;
-        
-        // Power-up symbol
-        ctx.fillStyle = '#ffffff';
-        ctx.font = '12px Arial';
-        ctx.textAlign = 'center';
-        const symbol = powerUp.type === 'expand' ? '↔' : 
-                      powerUp.type === 'multiball' ? '●' :
-                      powerUp.type === 'slowball' ? '⏱' : '♥';
-        ctx.fillText(symbol, powerUp.x, powerUp.y + 4);
+      // Particles
+      gameState.particles.forEach(p => {
+        ctx.globalAlpha = Math.max(0, p.life / p.maxLife);
+        ctx.fillStyle = p.color;
+        ctx.fillRect(p.x - p.size / 2, p.y - p.size / 2, p.size, p.size);
       });
+      ctx.globalAlpha = 1;
+
+      // Floating texts
+      gameState.floatingTexts.forEach(t => {
+        ctx.globalAlpha = Math.max(0, Math.min(1, t.life / 30));
+        ctx.fillStyle = t.color;
+        ctx.font = 'bold 16px ui-sans-serif, system-ui, sans-serif';
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        ctx.fillText(t.text, t.x, t.y);
+      });
+      ctx.globalAlpha = 1;
+
+      // "Launch" hint
+      const unlaunched = gameState.balls.find(b => !b.launched);
+      if (unlaunched) {
+        ctx.globalAlpha = 0.85;
+        ctx.fillStyle = '#e0e7ff';
+        ctx.font = 'bold 18px ui-sans-serif, system-ui, sans-serif';
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        ctx.fillText('Click or press Space to launch', CANVAS_WIDTH / 2, CANVAS_HEIGHT / 2 - 20);
+        ctx.globalAlpha = 1;
+      }
+
+      // Level banner
+      if (gameState.levelBannerFrames > 0) {
+        const t = gameState.levelBannerFrames / 120;
+        ctx.globalAlpha = Math.min(1, t * 1.4);
+        ctx.fillStyle = '#facc15';
+        ctx.font = 'bold 56px ui-sans-serif, system-ui, sans-serif';
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        ctx.fillText(`LEVEL ${gameState.level}`, CANVAS_WIDTH / 2, CANVAS_HEIGHT / 2);
+        ctx.globalAlpha = 1;
+      }
+
+      // Reversed-controls warning band
+      if (gameState.reverseTimer > 0) {
+        ctx.globalAlpha = 0.18 + 0.1 * Math.sin(gameState.reverseTimer / 4);
+        ctx.fillStyle = '#ef4444';
+        ctx.fillRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+        ctx.globalAlpha = 1;
+      }
     }
+
+    ctx.restore();
   }, [gameState]);
 
+  // Mouse paddle control — store the desired paddle X in a ref so the loop applies it,
+  // which means the paddle no longer freezes when the mouse leaves the canvas mid-move.
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
-
+    const handleMouseMove = (e: MouseEvent) => {
+      const rect = canvas.getBoundingClientRect();
+      const scaleX = canvas.width / rect.width;
+      const mouseX = (e.clientX - rect.left) * scaleX;
+      const w = gameState.paddleExpanded ? PADDLE_WIDTH * 1.5 : (gameState.shrinkTimer > 0 ? PADDLE_WIDTH * 0.7 : PADDLE_WIDTH);
+      mousePaddleXRef.current = mouseX - w / 2;
+    };
     canvas.addEventListener('mousemove', handleMouseMove);
     return () => canvas.removeEventListener('mousemove', handleMouseMove);
-  }, [handleMouseMove]);
+  }, [gameState.paddleExpanded, gameState.shrinkTimer]);
 
+  // Keyboard controls
   useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'ArrowLeft' || e.key === 'a' || e.key === 'A') {
+        keysDownRef.current.left = true;
+        e.preventDefault();
+      } else if (e.key === 'ArrowRight' || e.key === 'd' || e.key === 'D') {
+        keysDownRef.current.right = true;
+        e.preventDefault();
+      } else if (e.key === ' ' || e.key === 'Enter') {
+        e.preventDefault();
+        const hasUnlaunched = gameState.balls.some(b => !b.launched && b.active);
+        if (gameState.isPlaying && hasUnlaunched && !gameState.isPaused) {
+          launchAllStuckBalls();
+        } else if (gameState.isPlaying && !gameState.gameOver && !gameState.gameWon) {
+          pauseGame();
+        } else if (!gameState.isPlaying && !gameState.gameOver && !gameState.gameWon) {
+          startGame();
+        }
+      } else if (e.key === 'p' || e.key === 'P' || e.key === 'Escape') {
+        if (gameState.isPlaying && !gameState.gameOver && !gameState.gameWon) {
+          pauseGame();
+        }
+      } else if (e.key === 'r' || e.key === 'R') {
+        resetGame();
+      }
+    };
+    const onKeyUp = (e: KeyboardEvent) => {
+      if (e.key === 'ArrowLeft' || e.key === 'a' || e.key === 'A') keysDownRef.current.left = false;
+      if (e.key === 'ArrowRight' || e.key === 'd' || e.key === 'D') keysDownRef.current.right = false;
+    };
+    window.addEventListener('keydown', onKeyDown);
+    window.addEventListener('keyup', onKeyUp);
+    return () => {
+      window.removeEventListener('keydown', onKeyDown);
+      window.removeEventListener('keyup', onKeyUp);
+    };
+    // We deliberately read fresh state inside the handlers via closure; rebinding per relevant state change is fine.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [gameState.isPlaying, gameState.isPaused, gameState.gameOver, gameState.gameWon, gameState.balls]);
+
+  // Click on canvas: launch stuck balls
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const handleClick = () => launchAllStuckBalls();
+    canvas.addEventListener('click', handleClick);
+    return () => canvas.removeEventListener('click', handleClick);
+  }, []);
+
+  // Animation loop
+  useEffect(() => {
+    if (!gameState.isPlaying) return;
     const gameLoop = () => {
       updateGame();
       render();
       animationRef.current = requestAnimationFrame(gameLoop);
     };
-
-    if (gameState.isPlaying) {
-      animationRef.current = requestAnimationFrame(gameLoop);
-    }
-
+    animationRef.current = requestAnimationFrame(gameLoop);
     return () => {
-      if (animationRef.current) {
-        cancelAnimationFrame(animationRef.current);
-      }
+      if (animationRef.current) cancelAnimationFrame(animationRef.current);
     };
   }, [gameState.isPlaying, updateGame, render]);
 
-  // Touch controls for mobile (if not already present)
+  // Render once even when not playing (so the start/pause overlay sits over a real background)
+  useEffect(() => {
+    if (!gameState.isPlaying) render();
+  }, [gameState.isPlaying, render]);
+
+  // Touch controls
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
@@ -742,23 +1130,22 @@ export default function PongGame() {
       const touch = e.touches[0];
       const scaleX = canvas.width / rect.width;
       const touchX = (touch.clientX - rect.left) * scaleX;
-      const paddleWidth = gameState.paddleExpanded ? PADDLE_WIDTH * 1.5 : PADDLE_WIDTH;
-      const paddleX = Math.max(0, Math.min(CANVAS_WIDTH - paddleWidth, touchX - paddleWidth / 2));
-      setGameState(prev => ({
-        ...prev,
-        paddle: { ...prev.paddle, x: paddleX, width: paddleWidth },
-      }));
+      const w = gameState.paddleExpanded ? PADDLE_WIDTH * 1.5 : (gameState.shrinkTimer > 0 ? PADDLE_WIDTH * 0.7 : PADDLE_WIDTH);
+      mousePaddleXRef.current = touchX - w / 2;
       e.preventDefault();
     };
+    const handleTouchEnd = () => launchAllStuckBalls();
     canvas.addEventListener('touchstart', handleTouch, { passive: false });
     canvas.addEventListener('touchmove', handleTouch, { passive: false });
+    canvas.addEventListener('touchend', handleTouchEnd);
     return () => {
       canvas.removeEventListener('touchstart', handleTouch);
       canvas.removeEventListener('touchmove', handleTouch);
+      canvas.removeEventListener('touchend', handleTouchEnd);
     };
-  }, [gameState.isPlaying, gameState.isPaused, gameState.gameOver, gameState.gameWon, gameState.paddleExpanded]);
+  }, [gameState.isPlaying, gameState.isPaused, gameState.gameOver, gameState.gameWon, gameState.paddleExpanded, gameState.shrinkTimer]);
 
-  // Load leaderboard from localStorage
+  // Load leaderboard
   useEffect(() => {
     const stored = localStorage.getItem('breakout-leaderboard');
     if (stored) setLeaderboard(JSON.parse(stored));
@@ -766,12 +1153,11 @@ export default function PongGame() {
 
   // Show initials prompt after game over or victory
   useEffect(() => {
-    if ((gameState.gameOver || gameState.gameWon) && (gameState.score > 0)) {
+    if ((gameState.gameOver || gameState.gameWon) && gameState.score > 0) {
       setShowInitialsPrompt(true);
     }
-  }, [gameState.gameOver, gameState.gameWon]);
+  }, [gameState.gameOver, gameState.gameWon, gameState.score]);
 
-  // Save to leaderboard
   const saveToLeaderboard = () => {
     if (!initials.trim()) return;
     const entry = { initials: initials.trim().toUpperCase().slice(0, 3), score: gameState.score };
@@ -784,44 +1170,60 @@ export default function PongGame() {
   };
 
   const remainingBricks = gameState.bricks.filter(brick => !brick.destroyed).length;
+  const livesDisplay = gameState.lives <= 5
+    ? '❤️'.repeat(gameState.lives)
+    : `❤️ × ${gameState.lives}`;
 
   return (
     <div className="flex flex-col items-center justify-center min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900 p-2 sm:p-4 min-w-0">
       <div className="flex flex-col sm:flex-row gap-4 sm:gap-8 w-full max-w-[900px] mx-auto">
         <div className="bg-black/20 backdrop-blur-lg rounded-2xl p-2 sm:p-6 shadow-2xl border border-purple-500/20 w-full sm:w-auto">
           {/* Header */}
-          <div className="flex justify-between items-center mb-4">
+          <div className="flex justify-between items-center mb-4 flex-wrap gap-2">
             <div className="text-white">
               <h1 className="text-3xl font-bold bg-gradient-to-r from-blue-400 to-purple-400 bg-clip-text text-transparent">
                 BREAKOUT
               </h1>
               <p className="text-sm text-gray-400">Destroy all the bricks!</p>
             </div>
-            
+
             <div className="flex items-center gap-4 text-white">
               <div className="text-right">
-                <div className="text-sm text-gray-400">Score</div>
-                <div className="text-2xl font-bold text-blue-400">{gameState.score}</div>
+                <div className="text-xs text-gray-400">Score</div>
+                <div className="text-xl font-bold text-blue-400">{gameState.score}</div>
               </div>
               <div className="text-right">
-                <div className="text-sm text-gray-400">Bricks</div>
-                <div className="text-2xl font-bold text-purple-400">{remainingBricks}</div>
+                <div className="text-xs text-gray-400">Level</div>
+                <div className="text-xl font-bold text-yellow-300">{gameState.level}</div>
               </div>
               <div className="text-right">
-                <div className="text-sm text-gray-400">Lives</div>
-                <div className="text-2xl font-bold text-red-400">
-                  {'❤️'.repeat(gameState.lives)}
+                <div className="text-xs text-gray-400">Combo</div>
+                <div className="text-xl font-bold text-pink-300">
+                  {gameState.combo > 0 ? `×${1 + Math.floor((gameState.combo - 1) / 4)}` : '—'}
                 </div>
+              </div>
+              <div className="text-right">
+                <div className="text-xs text-gray-400">Bricks</div>
+                <div className="text-xl font-bold text-purple-400">{remainingBricks}</div>
+              </div>
+              <div className="text-right">
+                <div className="text-xs text-gray-400">Lives</div>
+                <div className="text-xl font-bold text-red-400 whitespace-nowrap">{livesDisplay}</div>
               </div>
             </div>
           </div>
 
-          {/* Power-up indicators */}
-          {(gameState.paddleExpanded || gameState.slowBallTimer > 0) && (
-            <div className="flex gap-2 mb-4 justify-center">
+          {/* Status indicators */}
+          {(gameState.paddleExpanded || gameState.slowBallTimer > 0 || gameState.shrinkTimer > 0 || gameState.reverseTimer > 0) && (
+            <div className="flex gap-2 mb-4 justify-center flex-wrap">
               {gameState.paddleExpanded && (
                 <div className="bg-green-500/20 text-green-400 px-3 py-1 rounded-full text-sm">
-                  Expanded Paddle ({Math.ceil(gameState.expandTimer / 60)}s)
+                  Expanded ({Math.ceil(gameState.expandTimer / 60)}s)
+                </div>
+              )}
+              {gameState.shrinkTimer > 0 && (
+                <div className="bg-red-500/20 text-red-300 px-3 py-1 rounded-full text-sm">
+                  Shrunk ({Math.ceil(gameState.shrinkTimer / 60)}s)
                 </div>
               )}
               {gameState.slowBallTimer > 0 && (
@@ -829,20 +1231,25 @@ export default function PongGame() {
                   Slow Ball ({Math.ceil(gameState.slowBallTimer / 60)}s)
                 </div>
               )}
+              {gameState.reverseTimer > 0 && (
+                <div className="bg-red-500/20 text-red-300 px-3 py-1 rounded-full text-sm">
+                  Reversed ({Math.ceil(gameState.reverseTimer / 60)}s)
+                </div>
+              )}
             </div>
           )}
 
-          {/* Game Canvas */}
+          {/* Canvas */}
           <div className="relative">
             <canvas
               ref={canvasRef}
               width={CANVAS_WIDTH}
               height={CANVAS_HEIGHT}
               style={{ width: '100%', maxWidth: 800, height: 'auto', aspectRatio: '4/3', touchAction: 'none' }}
-              className="border-2 border-purple-500/30 rounded-lg shadow-2xl select-none"
+              className="border-2 border-purple-500/30 rounded-lg shadow-2xl select-none cursor-none"
+              tabIndex={0}
             />
 
-            {/* Initials Prompt Overlay */}
             {showInitialsPrompt && (
               <div className="absolute inset-0 bg-black/80 backdrop-blur-sm rounded-lg flex items-center justify-center z-20">
                 <div className="text-center text-white">
@@ -874,7 +1281,6 @@ export default function PongGame() {
               </div>
             )}
 
-            {/* Game Over Overlay */}
             {gameState.gameOver && !showInitialsPrompt && (
               <div className="absolute inset-0 bg-black/80 backdrop-blur-sm rounded-lg flex items-center justify-center">
                 <div className="text-center text-white">
@@ -882,7 +1288,8 @@ export default function PongGame() {
                     Game Over
                   </h2>
                   <p className="text-xl mb-2">Final Score: <span className="text-blue-400 font-bold">{gameState.score}</span></p>
-                  <p className="text-lg mb-6">Bricks Destroyed: <span className="text-purple-400 font-bold">{gameState.bricks.length - remainingBricks}</span></p>
+                  <p className="text-lg mb-1">Reached Level <span className="text-yellow-300 font-bold">{gameState.level}</span></p>
+                  <p className="text-lg mb-6">Best Combo: <span className="text-pink-300 font-bold">×{1 + Math.floor(Math.max(0, gameState.bestCombo - 1) / 4)}</span> ({gameState.bestCombo} bricks)</p>
                   <button
                     onClick={resetGame}
                     className="bg-gradient-to-r from-blue-500 to-purple-500 hover:from-blue-600 hover:to-purple-600 px-6 py-3 rounded-lg font-semibold transition-all duration-200 transform hover:scale-105"
@@ -893,7 +1300,6 @@ export default function PongGame() {
               </div>
             )}
 
-            {/* Victory Overlay */}
             {gameState.gameWon && !showInitialsPrompt && (
               <div className="absolute inset-0 bg-black/80 backdrop-blur-sm rounded-lg flex items-center justify-center">
                 <div className="text-center text-white">
@@ -901,7 +1307,8 @@ export default function PongGame() {
                     Victory!
                   </h2>
                   <p className="text-xl mb-2">Final Score: <span className="text-blue-400 font-bold">{gameState.score}</span></p>
-                  <p className="text-lg mb-6">All bricks destroyed!</p>
+                  <p className="text-lg mb-1">Cleared <span className="text-yellow-300 font-bold">{gameState.level}</span> levels</p>
+                  <p className="text-lg mb-6">Best Combo: <span className="text-pink-300 font-bold">{gameState.bestCombo} bricks</span></p>
                   <button
                     onClick={resetGame}
                     className="bg-gradient-to-r from-green-500 to-blue-500 hover:from-green-600 hover:to-blue-600 px-6 py-3 rounded-lg font-semibold transition-all duration-200 transform hover:scale-105"
@@ -912,14 +1319,14 @@ export default function PongGame() {
               </div>
             )}
 
-            {/* Start Screen */}
             {!gameState.isPlaying && !gameState.gameOver && !gameState.gameWon && (
               <div className="absolute inset-0 bg-black/80 backdrop-blur-sm rounded-lg flex items-center justify-center">
-                <div className="text-center text-white">
+                <div className="text-center text-white px-4">
                   <h2 className="text-4xl font-bold mb-4 bg-gradient-to-r from-blue-400 to-purple-400 bg-clip-text text-transparent">
                     Ready to Break Out?
                   </h2>
-                  <p className="text-lg mb-6 text-gray-300">Move your mouse to control the paddle • Destroy all bricks to win!</p>
+                  <p className="text-lg mb-2 text-gray-300">Mouse, arrow keys, or A/D to move. Space to launch.</p>
+                  <p className="text-sm mb-6 text-gray-400">P or Esc to pause • R to reset • 5 levels • Build combos for x2, x3, x4…</p>
                   <button
                     onClick={startGame}
                     className="bg-gradient-to-r from-green-500 to-blue-500 hover:from-green-600 hover:to-blue-600 px-8 py-4 rounded-lg font-semibold text-lg transition-all duration-200 transform hover:scale-105"
@@ -930,7 +1337,6 @@ export default function PongGame() {
               </div>
             )}
 
-            {/* Pause Overlay */}
             {gameState.isPaused && gameState.isPlaying && (
               <div className="absolute inset-0 bg-black/80 backdrop-blur-sm rounded-lg flex items-center justify-center">
                 <div className="text-center text-white">
@@ -949,8 +1355,8 @@ export default function PongGame() {
           </div>
 
           {/* Controls */}
-          <div className="flex justify-between items-center mt-4">
-            <div className="flex gap-2">
+          <div className="flex justify-between items-center mt-4 flex-wrap gap-2">
+            <div className="flex gap-2 flex-wrap">
               {!gameState.isPlaying || gameState.gameOver || gameState.gameWon ? (
                 <button
                   onClick={startGame}
@@ -968,7 +1374,6 @@ export default function PongGame() {
                   {gameState.isPaused ? 'Resume' : 'Pause'}
                 </button>
               )}
-              
               <button
                 onClick={resetGame}
                 className="flex items-center gap-2 bg-red-500 hover:bg-red-600 text-white px-4 py-2 rounded-lg transition-colors"
@@ -988,23 +1393,29 @@ export default function PongGame() {
           </div>
 
           {/* Instructions */}
-          <div className="mt-4 text-center text-gray-400 text-sm">
-            <p>Move your mouse to control the paddle • Destroy all bricks to win • Collect power-ups for special abilities!</p>
+          <div className="mt-4 text-center text-gray-400 text-xs sm:text-sm">
+            <p>Mouse / ← → / A D to move • Space launches and pauses • P or Esc to pause • R to reset</p>
             <p className="mt-1">
-              <span className="text-yellow-400">↔</span> Expand Paddle • 
-              <span className="text-green-400 ml-2">●</span> Multi-ball • 
-              <span className="text-blue-400 ml-2">⏱</span> Slow Ball • 
+              <span className="text-yellow-400">⭐ ⬆️ 💥 💰</span> bonus bricks &nbsp;•&nbsp;
+              <span className="text-red-400">⬇️ 🔄 💔 ⚡ 🐢</span> trap bricks
+            </p>
+            <p className="mt-1">
+              Power-up drops:&nbsp;
+              <span className="text-yellow-400">↔</span> Expand •
+              <span className="text-green-400 ml-2">●</span> Multi-ball •
+              <span className="text-blue-400 ml-2">⏱</span> Slow Ball •
               <span className="text-red-400 ml-2">♥</span> Extra Life
             </p>
           </div>
         </div>
-        {/* Leaderboard Sidebar */}
+
+        {/* Leaderboard */}
         <div className="bg-black/40 backdrop-blur-lg rounded-2xl p-2 sm:p-6 shadow-2xl border border-yellow-400/30 min-w-0 w-full sm:min-w-[220px] sm:max-w-[260px] flex flex-col items-center h-fit self-start mt-4 sm:mt-0">
           <h3 className="text-2xl font-bold mb-4 text-yellow-400">Leaderboard</h3>
           <div className="flex justify-between w-full mb-2 px-1">
             <span className="font-mono text-gray-300 w-6"></span>
             <span className="font-mono text-gray-300 flex-1 text-center">Initials</span>
-            <span className="font-mono text-gray-300 w-10 text-right">Score</span>
+            <span className="font-mono text-gray-300 w-12 text-right">Score</span>
           </div>
           <ol className="text-lg w-full">
             {Array.from({ length: 10 }).map((_, i) => {
@@ -1013,7 +1424,7 @@ export default function PongGame() {
                 <li key={i} className="mb-2 flex justify-between">
                   <span className="font-mono text-gray-400 w-6">{i + 1}.</span>
                   <span className="font-mono text-white flex-1 text-center">{entry ? entry.initials : ''}</span>
-                  <span className="font-bold text-blue-300 w-10 text-right">{entry ? entry.score : ''}</span>
+                  <span className="font-bold text-blue-300 w-12 text-right">{entry ? entry.score : ''}</span>
                 </li>
               );
             })}


### PR DESCRIPTION
## Summary

The bonus/trap brick system advertised eight effects in its UI but most were never wired up — bonus bricks did literally nothing, and only the `slow-span` trap fired. The game also restarted the same wall on every "win," had no keyboard support, launched the ball in a random direction the instant you pressed Start, and gave no reward for skillful play.

This PR rebuilds the game-feel layer while keeping the Sentry/PostHog demo plumbing intact (every-brick `captureException`, all existing `posthog.capture` calls, and the intentional 400ms slow-span busy-wait).

### What's new

- **All bonus/trap effects implemented**: `extra-life`, `expand-paddle`, `multiball`, `score-boost`, `shrink-paddle`, `reverse-controls`, `lose-life`, `speed-up`. The `slow-span` trap stays at 400ms (intentional Sentry demo).
- **Launch-from-paddle**: ball sticks to the paddle until you click, tap, or press Space — same after each life loss. A "Click or press Space to launch" hint renders in-canvas.
- **Keyboard controls**: ← → / A D move the paddle, Space launches and pauses, P or Esc pause, R resets.
- **Combo multiplier**: x1 → x2 → x3 → x4 as you chain brick hits; resets on paddle contact. Floating "+points xN" text in-canvas.
- **5-level progression**: clearing a wall regenerates a new one, ball base speed +0.6 per level, "LEVEL N" banner, and a **+500-per-remaining-life bonus** on each clear.
- **Juice**: brick-break particles, ball trail, screen shake on hit/life-loss, paddle color swap when shrunk, pulsing red overlay while controls are reversed.
- **Min-angle clamp** on the ball so it can't degenerate into a flat horizontal loop.
- **Mouse-leave fix**: paddle X is now driven through a ref consumed by the game loop, so moving your cursor off the canvas no longer freezes the paddle mid-screen.
- **HUD fixes**: lives display collapses to `❤️ × N` past 5; added Level and Combo readouts; on-canvas legend updated.

### PostHog
Existing capture calls unchanged. New `level_cleared` event added for the per-level analytics funnel.

Note: this PR is paired with adding `VITE_PUBLIC_POSTHOG_KEY` / `VITE_PUBLIC_POSTHOG_HOST` to Vercel production env vars — those were missing, which is why no events were arriving from production. Merging this PR triggers the rebuild that bakes those values in.

## Test plan

- [ ] `npm test` passes (smoke test for title render)
- [ ] `npm run dev` — start a game, verify ball glues to paddle until Space/click
- [ ] Verify arrow keys / A&D / mouse all move the paddle; mouse-leave doesn't freeze it
- [ ] Hit 5+ bricks without paddle contact → confirm x2/x3 multiplier and floating text
- [ ] Trigger each bonus brick (gold) — verify extra-life, expand, multi-ball, score-boost effects
- [ ] Trigger each trap brick (red) — verify shrink, reverse, lose-life, speed-up, slow-span effects
- [ ] Clear level 1 → confirm "LEVEL 2" banner + life bonus + faster ball
- [ ] Clear all 5 levels → Victory screen shows correct level/combo stats
- [ ] On Vercel preview: confirm Network shows `/ingest/e/` requests and PostHog receives `game_started`

🤖 Generated with [Claude Code](https://claude.com/claude-code)