### PR TITLE
fix(posthog): Use regex source patterns to match trailing-slash paths

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,12 +1,12 @@
 {
   "rewrites": [
     {
-      "source": "/ingest/static/:path*",
-      "destination": "https://us-assets.i.posthog.com/static/:path*"
+      "source": "/ingest/static/(.*)",
+      "destination": "https://us-assets.i.posthog.com/static/$1"
     },
     {
-      "source": "/ingest/:path*",
-      "destination": "https://us.i.posthog.com/:path*"
+      "source": "/ingest/(.*)",
+      "destination": "https://us.i.posthog.com/$1"
     },
     {
       "source": "/ingest",


### PR DESCRIPTION
## Summary

PostHog events were firing from the SDK but every one was getting a 404 from Vercel, never reaching PostHog. Root cause: the `/ingest/:path*` rewrite uses path-to-regexp's `:path*` matcher, which **does not include trailing slashes** in its capture. PostHog's newer SDK (we set `defaults: '2025-05-24'` in `src/posthog.ts`) POSTs to `/ingest/i/v0/e/` with the trailing slash, so the rewrite missed.

Reproduction against the previous prod:

| Path | Status |
| --- | --- |
| `GET /ingest/decide` | 200 (proxy works) |
| `GET /ingest/decide/` | 404 (proxy misses) |
| `POST /ingest/i/v0/e` | 400 from PostHog (proxy works) |
| `POST /ingest/i/v0/e/` | 404 from Vercel (proxy misses) |

After this fix, both with- and without-trailing-slash paths reach PostHog, and POSTing an empty body to `/ingest/i/v0/e/` returns PostHog's expected 400: `failed to hydrate events from request: non-engage request missing event name attribute`.

The fix swaps the path-to-regexp `:path*` patterns for explicit `(.*)` regex captures, which match trailing slashes greedily.

## Test plan

- [x] `curl -X POST /ingest/i/v0/e/` returns a 400 from PostHog (not a 404 from Vercel)
- [ ] Open broken-breakout-game.vercel.app, play a round, confirm `POST /ingest/i/v0/e/` rows are 200 in the Network tab
- [ ] PostHog Live Events shows `game_started` and other events arriving

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated request routing configuration for ingest endpoints to improve path handling and forwarding.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rahulchhabria/breakout-game/pull/13?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->