### PR TITLE
fix(posthog): Use named path-to-regexp capture for /ingest rewrites

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,12 +1,12 @@
 {
   "rewrites": [
     {
-      "source": "/ingest/static/(.*)",
-      "destination": "https://us-assets.i.posthog.com/static/$1"
+      "source": "/ingest/static/:path(.*)",
+      "destination": "https://us-assets.i.posthog.com/static/:path"
     },
     {
-      "source": "/ingest/(.*)",
-      "destination": "https://us.i.posthog.com/$1"
+      "source": "/ingest/:path(.*)",
+      "destination": "https://us.i.posthog.com/:path"
     },
     {
       "source": "/ingest",


### PR DESCRIPTION
The actual reason replays and error tracking weren't showing up in PostHog: every `/ingest/*` request was returning a Vercel 404, not reaching PostHog at all.

The previous "regex trailing slash" fix (commit f01511b) switched the rewrites from `:path*` to `(.*)` + `$1`. But Vercel rewrites are parsed by **path-to-regexp**, not raw regex — `$1` is a regex backreference and is not a valid path-to-regexp substitution. Vercel silently failed to interpolate the destination and the rewrite never matched.

Verified live against the production deploy before this fix:

```
/ingest/static/recorder.js  → HTTP 404 (x-vercel-error: NOT_FOUND)
/ingest/decide/?v=3         → HTTP 404
/ingest/array/test/config   → HTTP 404
/ingest/s/                  → HTTP 404
```

The fix uses a **named** capture group with an inline regex body — `:path(.*)` — which both interpolates correctly into the destination as `:path` and captures the trailing slash that PostHog endpoints require.

After this merges and Vercel deploys, the same probes should return 200 (or the appropriate PostHog status), and session replay + error tracking should start landing in the dashboard for any session/exception generated on the live site.