### PR TITLE
fix(sentry): Log bug brick events without issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ coverage/
 .vercel
 .env
 .env*.local
+.sentry-deck/

--- a/src/components/PongGame.tsx
+++ b/src/components/PongGame.tsx
@@ -687,7 +687,7 @@ export default function PongGame() {
                   points: brick.points,
                   x: brick.x,
                   y: brick.y,
-                  createsIssue: brick.isBug,
+                  isBugBrick: brick.isBug,
                 },
               ];
 
@@ -1473,7 +1473,7 @@ export default function PongGame() {
           <div className="mt-4 text-center text-gray-400 text-xs sm:text-sm">
             <p>Mouse / ← → / A D to move • Space launches and pauses • P or Esc to pause • R to reset</p>
             <p className="mt-1">
-              <span className="text-cyan-300">🐛 bug bricks create new Sentry issues</span> &nbsp;•&nbsp;
+              <span className="text-cyan-300">🐛 bug bricks emit Sentry warning logs</span> &nbsp;•&nbsp;
               <span className="text-yellow-400">⭐ ⬆️ 💥 💰</span> bonus bricks &nbsp;•&nbsp;
               <span className="text-red-400">⬇️ 🔄 💔 ⚡</span> trap bricks
             </p>

--- a/src/sentry-demo.test.ts
+++ b/src/sentry-demo.test.ts
@@ -28,8 +28,8 @@ import {
 } from './sentry-demo';
 
 const brickBreak: BrickBreakTelemetry = {
-  id: 'session-1:level-1-brick-0-4',
-  brickId: 'level-1-brick-0-4',
+  id: 'session-1:level-1-brick-5-6',
+  brickId: 'level-1-brick-5-6',
   gameSessionId: 'session-1',
   level: 1,
   score: 70,
@@ -38,7 +38,7 @@ const brickBreak: BrickBreakTelemetry = {
   points: 70,
   x: 42,
   y: 60,
-  createsIssue: true,
+  isBugBrick: true,
 };
 
 describe('Sentry demo telemetry', () => {
@@ -46,27 +46,30 @@ describe('Sentry demo telemetry', () => {
     vi.clearAllMocks();
   });
 
-  it('creates a uniquely fingerprinted issue for a bug brick', () => {
+  it('regresses BREAKOUT-GAME-FR by logging the bug-brick hit without creating an issue', () => {
     emitBrickBreakTelemetry(brickBreak);
 
-    expect(mocks.captureException).toHaveBeenCalledOnce();
-    expect(mocks.captureException).toHaveBeenCalledWith(
-      expect.any(Error),
+    expect(mocks.warn).toHaveBeenCalledWith(
+      'Bug brick destroyed',
       expect.objectContaining({
-        fingerprint: ['breakout-bug-brick', 'session-1', 'level-1-brick-0-4'],
+        brick_id: 'level-1-brick-5-6',
+        game_session_id: 'session-1',
+        level: 1,
       }),
     );
+    expect(mocks.captureException).not.toHaveBeenCalled();
     expect(mocks.info).not.toHaveBeenCalled();
   });
 
   it('records an ordinary brick as a structured log without creating an issue', () => {
-    emitBrickBreakTelemetry({ ...brickBreak, createsIssue: false });
+    emitBrickBreakTelemetry({ ...brickBreak, isBugBrick: false });
 
     expect(mocks.info).toHaveBeenCalledWith(
       'Brick destroyed',
-      expect.objectContaining({ brick_id: 'level-1-brick-0-4', level: 1 }),
+      expect.objectContaining({ brick_id: 'level-1-brick-5-6', level: 1 }),
     );
     expect(mocks.captureException).not.toHaveBeenCalled();
+    expect(mocks.warn).not.toHaveBeenCalled();
   });
 
   it('creates a different fingerprint for each manual unique issue', () => {

--- a/src/sentry-demo.ts
+++ b/src/sentry-demo.ts
@@ -12,7 +12,7 @@ export interface BrickBreakTelemetry {
   points: number;
   x: number;
   y: number;
-  createsIssue: boolean;
+  isBugBrick: boolean;
 }
 
 const createId = () => {
@@ -38,22 +38,12 @@ export function emitBrickBreakTelemetry(event: BrickBreakTelemetry) {
     y: event.y,
   };
 
-  if (!event.createsIssue) {
+  if (!event.isBugBrick) {
     log.info('Brick destroyed', attributes);
     return;
   }
 
-  Sentry.captureException(new Error(`Bug brick destroyed: ${event.brickId}`), {
-    fingerprint: ['breakout-bug-brick', event.gameSessionId, event.brickId],
-    tags: {
-      trigger: 'bug-brick',
-      brick_id: event.brickId,
-      game_level: String(event.level),
-    },
-    contexts: {
-      brick: attributes,
-    },
-  });
+  log.warn('Bug brick destroyed', attributes);
 }
 
 export function triggerUniqueDemoIssue() {


### PR DESCRIPTION
Stop treating destroyed bug bricks as application exceptions.

The Sentry event is a handled `Error` originating in `emitBrickBreakTelemetry` after the expected level-1 brick collision. That path called `captureException` solely as demo instrumentation, turning normal game behavior into a high-priority issue.

Emit a structured warning log instead, preserve the brick and game attributes for observability, clarify the telemetry flag and player-facing copy, and cover the exact `level-1-brick-5-6` regression. This deliberately uses the logger rather than `captureMessage`, because captured messages also create issue events. Local `.sentry-deck` handoff metadata is now ignored.

Validated with the targeted regression test, the full six-test suite, coverage, TypeScript, ESLint, a production build with authenticated Sentry source-map processing, and diff checks.

Fixes [BREAKOUT-GAME-FR](https://rc-sentry-projects.sentry.io/issues/7672072162/).